### PR TITLE
Make lgmask and normalize_mri run on perl 5.16 and newer

### DIFF
--- a/lgmask.in
+++ b/lgmask.in
@@ -20,12 +20,10 @@
 #$State: Exp $
 #---------------------------------------------------------------------------
 
-require "ctime.pl";
-
 use warnings "all";
 
 use MNI::FileUtilities qw(:check);
-use MNI::MincUtilities qw(:history);
+use MNI::MincUtilities qw(:history :geometry);
 
 use MNI::Startup;
 use MNI::Spawn;
@@ -92,7 +90,7 @@ HELP
 #-----------------------------------------------------------------------------
 sub Initialize
 {
-    chop ($ctime = &ctime(time));
+    $ctime = localtime(time);
     $HistoryLine = "$ctime>>> $0 @ARGV\n";
 
     $Clobber  = 0;
@@ -207,7 +205,7 @@ sub LowGradientMask {
 
 	my($file) = $InFile;
 	# Create gradient volume
-	if (defined(@SubSample)) {
+	if (@SubSample) {
 	    &volume_params($file, undef, \@step, undef, undef);
 	    
 	    $SubSampledVol = "${TmpDir}/subsampled.mnc";

--- a/normalize_mri.in
+++ b/normalize_mri.in
@@ -19,7 +19,6 @@
 #$State: Exp $
 #---------------------------------------------------------------------------
 
-require "ctime.pl";
 use warnings "all";
 use Getopt::Tabular;
 
@@ -166,7 +165,7 @@ HELP
 #-----------------------------------------------------------------------------
 sub Initialize
 {
-    chop ($ctime = &ctime(time));
+    $ctime = localtime(time);
     $HistoryLine = "$ctime>>> $0 @ARGV";
 
     $Clobber   = 0;


### PR DESCRIPTION
Both scripts die before they do any work, and have since 2012. Found by running every installed command in the toolkit's relocatable tarball (BIC-MNI/minc-toolkit-v2#234).

## What is broken

| Script | Failure | Since |
| --- | --- | --- |
| `lgmask` | `Can't use 'defined(@array)'` at compile time, line 210 | perl 5.22 (2015) |
| `lgmask`, `normalize_mri` | `Can't locate ctime.pl in @INC` at run time | perl 5.16 (2012) |
| `lgmask -subsample` | `Undefined subroutine &main::volume_params` | always |

`lgmask` never even reported the `ctime.pl` problem: compilation ended first. `normalize_mri` calls `lgmask`, so it crashed on `lgmask` even after its own fix.

## The fixes

**`require "ctime.pl"`.** Perl removed the perl4-era `.pl` libraries in 5.16; they live on CPAN as `Perl4::CoreLibs`. The only use here is one history line, so no dependency is needed. `localtime(time)` returns the same string `ctime.pl` built, which is also what the compiled MINC tools write through C `ctime()`, so history lines stay consistent:

```
Sat Sep  5 14:31:56 2026>>> lgmask -clobber in.mnc out.mnc
```

`chop` goes with it, because `localtime` has no trailing newline. `N3/src/NUcorrect/nu_evaluate.in` already builds its history line this way.

**`defined(@SubSample)`.** A compile-time error since perl 5.22. `@SubSample` starts empty and `Getopt::Tabular` fills it, so `if (@SubSample)` is both the modern spelling and what the old form meant.

**`volume_params`.** With the compile error gone, `-subsample` reached the next problem: the script imports only `:history` from `MNI::MincUtilities`, and `volume_params` is in `:geometry`.

## Checked

Against a 64³ phantom, with the toolkit's own perl libraries on `PERL5LIB`:

- `lgmask in.mnc out.mnc` → writes a volume, history line correct.
- `lgmask -subsample 2 2 2 in.mnc out.mnc` → writes a volume.
- `normalize_mri in.mnc out.mnc` → completes and writes a volume.

Before this change all three end in a perl error and write nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5NQ3wnC2yygmxWeM5NxNm